### PR TITLE
Added target to generate portable images for publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#image creation output
+build.log
+images/build.log
+
 # Compiled class file
 *.class
 

--- a/images/image.sh
+++ b/images/image.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+## resolve folder of this script, following all symlinks:
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly THIS_SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+readonly SCRIPT_DIR=`readlink -f "$THIS_SCRIPT_DIR/../"`
+
+THE_TERRIBLE_INTERNAL_JRD=true
+. $SCRIPT_DIR/start.sh
+
+
+set -ex
+set -o pipefail
+
+NAME=`basename $JRD | sed "s;.jar;;"`
+
+TARGET_DIR="$SCRIPT_DIR/images/target"
+IMAGE_DIR="$TARGET_DIR/image"
+LIB_DIR="$IMAGE_DIR/libs"
+DEPS_DIR="$LIB_DIR/deps"
+DECOMPS="$LIB_DIR/decompilers"
+
+rm -rvf "$TARGET_DIR"
+mkdir "$TARGET_DIR"
+mkdir "$IMAGE_DIR"
+mkdir "$LIB_DIR"
+mkdir "$DEPS_DIR"
+mkdir "$DECOMPS"
+
+cp "$RSYNTAXTEXTAREA" "$DEPS_DIR"
+cp "$GSON" "$DEPS_DIR"
+cp "$BYTEMAN" "$DEPS_DIR"
+cp "$JRD" "$DEPS_DIR"
+cp "$SCRIPT_DIR/decompiler_agent/target/decompiler-agent-2.0.0-SNAPSHOT.jar" "$LIB_DIR"
+
+# if PLUGINS=TRUE && mvn install -PdownloadPlugins was run, and you really wont them to include plugins in images
+if [ "x$PLUGINS" == "xTRUE" ] ; then
+  for dec in procyon fernflower ; do
+    mkdir "$DECOMPS/$dec"
+    jars=`find $MVN_SOURCE | grep -e $dec | grep \.jar$`
+    for jar in $jars ; do
+      cp "$jar" "$DECOMPS/$dec"
+    done
+    rmdir "$DECOMPS/$dec" 2>/dev/null || true
+  done
+  rmdir "$DECOMPS" 2>/dev/null || true
+  SUFFIX="-with-decompilers"
+fi
+
+echo "creating $IMAGE_DIR/start.sh"
+cat $SCRIPT_DIR/start.sh | sed "s/PURPOSE=DEVELOPMENT/PURPOSE=RELEASE/" > $IMAGE_DIR/start.sh
+
+pushd $TARGET_DIR
+cp -r $IMAGE_DIR $NAME$SUFFIX
+tar -cJf  $TARGET_DIR/$NAME$SUFFIX.tar.xz $NAME$SUFFIX
+if which zip  ; then
+  zip  $TARGET_DIR/$NAME$SUFFIX.zip `find $NAME$SUFFIX`
+fi
+popd

--- a/images/pom.xml
+++ b/images/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>java-runtime-decompiler</groupId>
+        <artifactId>java-runtime-decompiler</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <artifactId>java-runtime-decompiler-images</artifactId>
+    <name>Images</name>
+    <description>Helper to cvreate release images</description>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>java-runtime-decompiler</groupId>
+            <artifactId>runtime-decompiler</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>java-runtime-decompiler</groupId>
+            <artifactId>decompiler-agent</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>images</id>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <artifactId>exec-maven-plugin</artifactId>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <version>1.6.0</version>
+                            <executions>
+                                <execution>
+                                <id>build-image</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <commandlineArgs>${basedir}/image.sh ${project.version}</commandlineArgs>
+                                    <outputFile>${basedir}/build.log</outputFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>clean-image</id>
+                                <phase>clean</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>rm</executable>
+                                    <commandlineArgs>-rvf ${basedir}/target</commandlineArgs>
+                                    <outputFile>${basedir}/build.log</outputFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
     <modules>
         <module>runtime-decompiler</module>
         <module>decompiler_agent</module>
+        <module>images</module>
     </modules>
     <groupId>java-runtime-decompiler</groupId>
     <artifactId>java-runtime-decompiler</artifactId>
     <version>2.0.0-SNAPSHOT</version>
-
 </project>

--- a/start.sh
+++ b/start.sh
@@ -1,18 +1,53 @@
 #!/bin/bash
+
+## resolve folder of this script, following all symlinks:
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly PORTABLE_JRD_HOME="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
 # Locate JDK from $PATH
 javac_home=$(command -v javac)
 javac_home=$(readlink -f "$javac_home")
 javac_home="$(dirname "$(dirname "$javac_home")")"
 
+PURPOSE=DEVELOPMENT
+MVN_SOURCE="$HOME/.m2/repository"
+
+function findLib(){
+  if [ "x$PURPOSE" = "xDEVELOPMENT" ] ; then
+    BASE="$MVN_SOURCE"
+    GROUP="$1"
+    FILENAME="$2"
+  else
+    BASE="$PORTABLE_JRD_HOME/libs/deps"
+    GROUP=""
+    FILENAME="$2"
+  fi
+  find "$BASE/$GROUP"  | grep "$FILENAME$"   | sort -V | tail -n 1
+}
+
 TOOLS="$javac_home"/lib/tools.jar
-RSYNTAXTEXTAREA=$(find "$HOME"/.m2/repository/com/fifesoft/rsyntaxtextarea/*/rsyntaxtextarea-*.jar -printf %p:)
-GSON=$(find "$HOME"/.m2/repository/com/google/code/gson/gson/*/gson-*.jar -printf %p:)
-BYTEMAN=$(find "$HOME"/.m2/repository/org/jboss/byteman/byteman-install/*/byteman-install-*.jar -printf %p:)
-JRD=$(find "$HOME"/.m2/repository/java-runtime-decompiler/runtime-decompiler/*/runtime-decompiler-*.jar -printf %p:)
+
+readonly RSYNTAXTEXTAREA=$(findLib "com/fifesoft/rsyntaxtextarea" "rsyntaxtextarea-.*\.jar" )
+readonly GSON=$(findLib "com/google/code/gson/gson" "gson-.*\.jar")
+readonly BYTEMAN=$(findLib "org/jboss/byteman/byteman-install" "byteman-install-.*\.jar")
+readonly JUST_BUILD_JRD=`find "$PORTABLE_JRD_HOME"/runtime-decompiler/target/runtime-decompiler-*-SNAPSHOT.jar 2> /dev/null`
+if [ -f "$JUST_BUILD_JRD" ] ; then
+  readonly JRD="$JUST_BUILD_JRD"
+else
+  readonly JRD=$(findLib "java-runtime-decompiler/runtime-decompiler" "runtime-decompiler-.*\.jar")
+fi
+
+if [ "x$THE_TERRIBLE_INTERNAL_JRD" == "xtrue" ] ; then
+  return 0
+fi
 # launch application
 "$javac_home"/bin/java -cp "$TOOLS":\
-"$RSYNTAXTEXTAREA":\
-"$GSON":\
-"$BYTEMAN":\
-"$JRD"\
- org.jrd.backend.data.Main
+"$JRD":"$RSYNTAXTEXTAREA":"$GSON":"$BYTEMAN" \
+ org.jrd.backend.data.Main "$@"


### PR DESCRIPTION
Hello! This PR shold help with releasing and distribution.

Whole approach is much simplified version of:
 * https://github.com/AdoptOpenJDK/IcedTea-Web/blob/master/launchers/configure.sh
 * https://github.com/AdoptOpenJDK/IcedTea-Web/blob/master/launchers/build.sh
 * https://github.com/AdoptOpenJDK/IcedTea-Web/blob/master/launchers/shell-launcher/launchers.sh.in

It  had to touch the start.sh again, to make it portable-friendly (until now it was developer friendly, and I wished to keep also this behaviour)\

It works in this way:
* mvn install -Pimages - will create  images/target and portable binary, and when on it, also tar.gz and zip archives for posting.
* mvn clean -Pimages will celane that target
If you run the -PdownloadDecompilers, then you can do:
PLUGINS=TRUE mvn install -Pimages nd then the images will contain also decompilers. TBH I'm not fan of this, but can make setup really easy.

If the second wopuld be the choice, then (as separate changeset) the plugin jsons can be somehow twinked to run out of the box. (I guess it will need changes also in code)

Thoughts?