### PR TITLE
Added batch start file for Windows

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,23 @@
+@echo off
+
+:: Find Java tools.jar
+set TOOLS="%JAVA_HOME%\lib\tools.jar"
+
+:: Save decompiler directory and cd to Maven Local Repository
+set "wd=%cd%"
+cd %userprofile%/.m2
+
+:: Recusively find libraries
+FOR /f "delims=" %%i IN ('dir *rsyntaxtextarea-*.jar /B /S') DO set RSYNTAXTEXTAREA=%%i
+FOR /f "delims=" %%i IN ('dir *gson-*.jar /B /S') DO set GSON=%%i
+FOR /f "delims=" %%i IN ('dir *byteman-install-*.jar /B /S') DO set BYTEMAN=%%i
+FOR /f "delims=" %%i IN ('dir *runtime-decompiler-*.jar /B /S') DO set JRD=%%i
+
+:: cd back to cwd
+cd %wd%
+
+:: Concatenate classpath and launch the decompiler
+set CLASSPATH=%TOOLS%;%RSYNTAXTEXTAREA%;%GSON%;%BYTEMAN%;%JRD%;
+java -cp %CLASSPATH% org.jrd.backend.data.Main
+
+exit


### PR DESCRIPTION
Inspired by the start.sh. So far it relies on the JAVA_HOME environment variable and a recursive dir search to find the required libraries in Maven's local repository.