### PR TITLE
Changed to multiplatform file separators

### DIFF
--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/Directories.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/Directories.java
@@ -1,10 +1,12 @@
 package org.jrd.backend.data;
 
+import java.io.File;
+
 public final class Directories {
 
-    private static final String XDG_CONFIG_SUFFIX = "/conf";
-    private static final String XDG_PLUGIN_SUFFIX = "/plugins";
-    private static final String XDG_JRD_HOME = "/.config/java-runtime-decompiler";
+    private static final String XDG_CONFIG_SUFFIX = File.separator + "conf";
+    private static final String XDG_PLUGIN_SUFFIX = File.separator + "plugins";
+    private static final String XDG_JRD_HOME = File.separator + ".config" + File.separator + "java-runtime-decompiler";
 
     private Directories(){
     }

--- a/runtime-decompiler/src/main/java/org/jrd/backend/decompiling/DecompilerWrapperInformation.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/decompiling/DecompilerWrapperInformation.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -204,8 +206,13 @@ public class DecompilerWrapperInformation {
         } else if (fileLocation.startsWith("/usr/share/")) {
             scope = "user shared";
 
-        } else if (fileLocation.startsWith(Directories.getXdgJrdBaseDir())) {
-            scope = LOCAL_SCOPE;
+        } else{
+            Path wrapperFile = Paths.get(fileLocation);
+            Path baseDir = Paths.get(Directories.getXdgJrdBaseDir());
+
+            if(wrapperFile.startsWith(baseDir)){
+                scope = LOCAL_SCOPE;
+            }
         }
         return scope;
     }


### PR DESCRIPTION
Fixes broken plugin deletion on Windows, which needed plugin scope
from DecompilerWrapperInformation to be local, which checked file path
with "\" against hardcoded "/.config/java-runtime-decompiler" here.