### PR TITLE
NestedJarsEditing rewritten

### DIFF
--- a/runtime-decompiler/src/main/java/org/jrd/backend/communication/FsAgent.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/communication/FsAgent.java
@@ -132,13 +132,12 @@ public class FsAgent implements JrdAgent {
                             throw new IOException("Trying to find class but no class is specified");
                         }
                         ArchiveManager am = ArchiveManager.getInstance();
-                        am.setFile(c);
-                        if (am.isClassInFile(clazz)) {
+                        if (am.isClassInFile(clazz, c)) {
                             if (am.needExtract()) {
-                                File f = am.unpack();
+                                File f = am.unpack(c);
                                 T ret = onEntryOther(f, clazz, op);
                                 if (op instanceof WriteingCpOperator) {
-                                    am.pack();
+                                    am.pack(c);
                                 }
                                 return ret;
                             } else {

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
@@ -18,13 +18,13 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class ArchiveManager {
     private static ArchiveManager singleton = null;
 
-    public static ArchiveManager getInstance() {
-        if (singleton == null) {
-            singleton = new ArchiveManager();
-        }
-        return singleton;
+    private static class ArchiveManagerHolder {
+        private static final ArchiveManager INSTANCE = new ArchiveManager();
     }
 
+    public static ArchiveManager getInstance() {
+        return ArchiveManagerHolder.INSTANCE;
+    }
 
     final String tmpdir = System.getProperty("java.io.tmpdir");
     final String fileSeparator = System.getProperty("file.separator");

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
@@ -91,6 +91,10 @@ public class ArchiveManager {
      */
     public static boolean shouldOpen(String n) throws IOException {
         /* This way has been selected as there's no other "easier" way of determining if it is an archive.
+           We initially tried to use streams - open a stream over ZipEntry, but because of the way streams work this method is not possible as it will
+           edit the original entry and there's no way of returning back. This caused some branches to be skipped while searching.
+           Also closing stream derived from another stream, will close all streams that are connected, even the parent stream. This was a concern as there might be a lot of
+           streams opened and none of them could be closed until they are all fully searched.
          * If you wish to add a format, feel free to PR */
         String name = n.toLowerCase();
         return name.endsWith(".zip") || name.endsWith(".jar") || name.endsWith(".war") || name.endsWith(".ear");

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
@@ -25,14 +25,14 @@ public class ArchiveManager {
         return singleton;
     }
 
-    File c;
+
     final String tmpdir = System.getProperty("java.io.tmpdir");
     final String fileSeparator = System.getProperty("file.separator");
     ArrayList<String> currentPathInJars = new ArrayList<>();
     ArchivePathManager pathManager = new ArchivePathManager();
     int currentD = 0;
 
-    public void setFile(File c) {this.c = c;}
+    //public void setFile(File c) {this.c = c;}
 
     /**
      * Finds out whether desired class is contained in <code>c</code>
@@ -41,7 +41,7 @@ public class ArchiveManager {
      * @return Whether class is in this file
      * @throws IOException Error while reading streams
      */
-    public boolean isClassInFile(String clazz) throws IOException {
+    public boolean isClassInFile(String clazz, File c) throws IOException {
         ZipInputStream zis = new ZipInputStream(new FileInputStream(c));
         if (pathManager.wasFound() && pathManager.getCurrentClazz().equals(clazz)) {
             return true;
@@ -115,7 +115,7 @@ public class ArchiveManager {
      * @return .jar containing desired class
      * @throws IOException Error while reading streams
      */
-    public File unpack() throws IOException {
+    public File unpack(File c) throws IOException {
         if (pathManager.isExtracted()) {
             // If file is already extracted, return the extracted one
             return new File(tmpdir + fileSeparator + "jrd" + fileSeparator + (pathManager.getPathSize() - 2) + fileSeparator + (pathManager.get(pathManager.getPathSize() - 1)));
@@ -202,7 +202,7 @@ public class ArchiveManager {
     /**
      * Packs unpacked files
      */
-    public void pack() throws IOException {
+    public void pack(File c) throws IOException {
         // Go from end to start
         int i = pathManager.getPathSize();
         i -= 2;

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
@@ -27,6 +27,7 @@ public class ArchiveManager {
 
     File c;
     final String tmpdir = System.getProperty("java.io.tmpdir");
+    final String fileSeparator = System.getProperty("file.separator");
     ArrayList<String> currentPathInJars = new ArrayList<>();
     ArchivePathManager pathManager = new ArchivePathManager();
     int currentD = 0;
@@ -113,11 +114,11 @@ public class ArchiveManager {
     public File unpack() throws IOException {
         if (pathManager.isExtracted()) {
             // If file is already extracted, return the extracted one
-            return new File(tmpdir + "/jrd/" + (pathManager.getPathSize() - 2) + "/" + (pathManager.get(pathManager.getPathSize() - 1)));
+            return new File(tmpdir + fileSeparator + "jrd" + fileSeparator + (pathManager.getPathSize() - 2) + fileSeparator + (pathManager.get(pathManager.getPathSize() - 1)));
         }
         // Create my dir in tmpdir
         delete();
-        File f = new File(tmpdir + "/jrd/");
+        File f = new File(tmpdir + fileSeparator + "jrd" + fileSeparator);
         if (f.mkdir()) {
             File ret = recursiveUnpack(c);
             if (ret != null) {
@@ -136,7 +137,7 @@ public class ArchiveManager {
      * @throws IOException
      */
     private File recursiveUnpack(File toUnpack) throws IOException {
-        File destDir = new File(tmpdir + "/jrd/" + currentD);
+        File destDir = new File(tmpdir + fileSeparator + "jrd" + fileSeparator + currentD);
         if (destDir.mkdir()) {
             byte[] buffer = new byte[1024];
             try (ZipInputStream zis = new ZipInputStream(new FileInputStream(toUnpack))) {
@@ -167,11 +168,11 @@ public class ArchiveManager {
         }
         currentD++;
         if (currentD == pathManager.getPathSize() - 1) {
-            return new File(destDir.getAbsolutePath() + "/" + pathManager.get(currentD));
+            return new File(destDir.getAbsolutePath() + fileSeparator + pathManager.get(currentD));
         } else if (currentD == pathManager.getPathSize()) {
             throw new IOException("Unknown exception");
         }
-        return recursiveUnpack(new File(destDir.getAbsolutePath() + "/" + pathManager.get(currentD)));
+        return recursiveUnpack(new File(destDir.getAbsolutePath() + fileSeparator + pathManager.get(currentD)));
     }
 
     /**
@@ -203,11 +204,11 @@ public class ArchiveManager {
         i -= 2;
         for (; i >= 0; i--) {
             // Create new zip that will contain edited files
-            String[] tmp = pathManager.get(i).split("/");
-            String path = tmpdir + "/jrd/" + tmp[tmp.length - 1] + "/";
+            String[] tmp = pathManager.get(i).split(fileSeparator);
+            String path = tmpdir + fileSeparator + "jrd" + fileSeparator + tmp[tmp.length - 1] + fileSeparator;
             FileOutputStream fileStream = new FileOutputStream(path);
             ZipOutputStream zOut = new ZipOutputStream(fileStream);
-            File f2zip = new File(tmpdir + "/jrd/" + (i));
+            File f2zip = new File(tmpdir + fileSeparator + "jrd" + fileSeparator + (i));
             for (File f : f2zip.listFiles()) {
                 recursiveZip(f, f.getName(), zOut);
             }
@@ -216,7 +217,7 @@ public class ArchiveManager {
             fileStream.close();
             // Move it into the temp file if it's not last, so it can be packaged
             if (i > 0) {
-                Files.copy(Path.of(path), Path.of(tmpdir + "/jrd/" + (i - 1) + "/" + pathManager.get(i)), REPLACE_EXISTING);
+                Files.copy(Path.of(path), Path.of(tmpdir + fileSeparator + "jrd" + fileSeparator + (i - 1) + fileSeparator + pathManager.get(i)), REPLACE_EXISTING);
             } else {
                 // It's the last, replace the original
                 Files.copy(Path.of(path), c.toPath(), REPLACE_EXISTING);
@@ -235,8 +236,8 @@ public class ArchiveManager {
      */
     public void recursiveZip(File f2zip, String fName, ZipOutputStream zOut) throws IOException {
         if (f2zip.isDirectory()) {
-            if (!fName.endsWith("/")) {
-                fName += "/";
+            if (!fName.endsWith(fileSeparator)) {
+                fName += fileSeparator;
             }
             zOut.putNextEntry(new ZipEntry(fName));
             zOut.closeEntry();
@@ -265,7 +266,7 @@ public class ArchiveManager {
      */
     public boolean delete() {
         currentD = 0;
-        return deleteRecursive(new File(tmpdir + "/jrd/"));
+        return deleteRecursive(new File(tmpdir + fileSeparator + "jrd" + fileSeparator));
     }
 
     /**

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
@@ -32,8 +32,6 @@ public class ArchiveManager {
     ArchivePathManager pathManager = new ArchivePathManager();
     int currentD = 0;
 
-    //public void setFile(File c) {this.c = c;}
-
     /**
      * Finds out whether desired class is contained in <code>c</code>
      *


### PR DESCRIPTION
Nested Jars are now editable and will be overridden once uploaded. This uses a temp folder in default OS temp directory serving as a cache.

Note that delete() serves for deleting the temp files from disk, not to edit the objects, so it should not be against good practices as the previous cache implementation.