### PR TITLE
CPLC main interface name

### DIFF
--- a/runtime-decompiler/pom.xml
+++ b/runtime-decompiler/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>io.github.mkoncek</groupId>
             <artifactId>classpathless-compiler</artifactId>
-            <version>[1.3,)</version>
+            <version>[1.4,)</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/runtime-decompiler/src/main/java/org/jrd/backend/communication/RuntimeCompilerConnector.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/communication/RuntimeCompilerConnector.java
@@ -4,7 +4,7 @@ import io.github.mkoncek.classpathless.api.ClassIdentifier;
 import io.github.mkoncek.classpathless.api.ClassesProvider;
 import io.github.mkoncek.classpathless.api.IdentifiedBytecode;
 import io.github.mkoncek.classpathless.api.IdentifiedSource;
-import io.github.mkoncek.classpathless.api.InMemoryCompiler;
+import io.github.mkoncek.classpathless.api.ClasspathlessCompiler;
 import io.github.mkoncek.classpathless.api.MessagesListener;
 import org.jrd.backend.core.AgentRequestAction;
 import org.jrd.backend.core.VmDecompilerStatus;
@@ -31,7 +31,7 @@ public class RuntimeCompilerConnector {
 
     private static final boolean slow = true;
 
-    public static class DummyRuntimeCompiler implements InMemoryCompiler {
+    public static class DummyRuntimeCompiler implements ClasspathlessCompiler {
 
         @Override
         public Collection<IdentifiedBytecode> compileClass(ClassesProvider classesProvider, Optional<MessagesListener> messagesListener, IdentifiedSource... identifiedSources) {
@@ -122,7 +122,7 @@ public class RuntimeCompilerConnector {
         }
     }
 
-    public static class ForeignCompilerWrapper implements InMemoryCompiler {
+    public static class ForeignCompilerWrapper implements ClasspathlessCompiler {
         private final PluginManager pluginManager;
         private final DecompilerWrapperInformation currentDecompiler;
 

--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/Cli.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/Cli.java
@@ -4,7 +4,7 @@ import io.github.mkoncek.classpathless.api.ClassIdentifier;
 import io.github.mkoncek.classpathless.api.ClassesProvider;
 import io.github.mkoncek.classpathless.api.IdentifiedBytecode;
 import io.github.mkoncek.classpathless.api.IdentifiedSource;
-import io.github.mkoncek.classpathless.api.InMemoryCompiler;
+import io.github.mkoncek.classpathless.api.ClasspathlessCompiler;
 import io.github.mkoncek.classpathless.api.MessagesListener;
 import org.jrd.backend.communication.RuntimeCompilerConnector;
 import org.jrd.backend.core.AgentRequestAction;
@@ -317,7 +317,7 @@ public class Cli {
             }
         }
         System.err.println(s);
-        InMemoryCompiler rc;
+        ClasspathlessCompiler rc;
         if (haveCompiler) {
             rc = new RuntimeCompilerConnector.ForeignCompilerWrapper(pluginManager, decompiler);
         } else {

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/MainFrame/RewriteClassDialog.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/MainFrame/RewriteClassDialog.java
@@ -4,7 +4,7 @@ import io.github.mkoncek.classpathless.api.ClassIdentifier;
 import io.github.mkoncek.classpathless.api.ClassesProvider;
 import io.github.mkoncek.classpathless.api.IdentifiedBytecode;
 import io.github.mkoncek.classpathless.api.IdentifiedSource;
-import io.github.mkoncek.classpathless.api.InMemoryCompiler;
+import io.github.mkoncek.classpathless.api.ClasspathlessCompiler;
 import io.github.mkoncek.classpathless.api.MessagesListener;
 import org.jrd.backend.communication.RuntimeCompilerConnector;
 import org.jrd.backend.core.DecompilerRequestReceiver;
@@ -375,7 +375,7 @@ public class RewriteClassDialog extends JDialog {
     private static RewriteClassDialog.CompilationWithResult xompileWithGui(VmInfo vmInfo, VmManager vmManager, PluginManager pm, DecompilerWrapperInformation currentDecompiler, boolean haveCompiler,
             IdentifiedSource... sources) {
         ClassesProvider cp = new RuntimeCompilerConnector.JRDClassesProvider(vmInfo, vmManager);
-        InMemoryCompiler rc;
+        ClasspathlessCompiler rc;
         if (haveCompiler) {
             rc = new RuntimeCompilerConnector.ForeignCompilerWrapper(pm, currentDecompiler);
         } else {
@@ -456,7 +456,7 @@ public class RewriteClassDialog extends JDialog {
     }
 
     private static class CompilationWithResult implements Runnable {
-        private final InMemoryCompiler rc;
+        private final ClasspathlessCompiler rc;
         private final ClassesProvider cp;
         private final JTextArea compilationLog;
         private final IdentifiedSource[] sources;
@@ -464,7 +464,7 @@ public class RewriteClassDialog extends JDialog {
         private Collection<IdentifiedBytecode> result;
 
 
-        public CompilationWithResult(InMemoryCompiler rc, ClassesProvider cp, JTextArea compilationLog, IdentifiedSource... sources) {
+        public CompilationWithResult(ClasspathlessCompiler rc, ClassesProvider cp, JTextArea compilationLog, IdentifiedSource... sources) {
             this.rc = rc;
             this.cp = cp;
             this.compilationLog = compilationLog;

--- a/runtime-decompiler/src/main/java/org/jrd/frontend/Utils.java
+++ b/runtime-decompiler/src/main/java/org/jrd/frontend/Utils.java
@@ -3,7 +3,7 @@ package org.jrd.frontend;
 import io.github.mkoncek.classpathless.api.ClassIdentifier;
 import io.github.mkoncek.classpathless.api.ClassesProvider;
 import io.github.mkoncek.classpathless.api.IdentifiedSource;
-import io.github.mkoncek.classpathless.api.InMemoryCompiler;
+import io.github.mkoncek.classpathless.api.ClasspathlessCompiler;
 import org.jrd.backend.communication.RuntimeCompilerConnector;
 import org.jrd.backend.core.AgentRequestAction;
 import org.jrd.backend.core.DecompilerRequestReceiver;


### PR DESCRIPTION
I don't like the old name. The class name is the most important aspect and should reflect the name of the project. Therefore i would like to change it with the release of `1.4`.
I am letting you know before i do that.
This PR can wait until the release of 1.4.