### PR TITLE
Fixing bug introduced in c305169d

### DIFF
--- a/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
+++ b/runtime-decompiler/src/main/java/org/jrd/backend/data/ArchiveManager.java
@@ -250,7 +250,7 @@ public class ArchiveManager {
     public void recursiveZip(File f2zip, String fName, ZipOutputStream zOut) throws IOException {
         if (f2zip.isDirectory()) {
             if (!fName.endsWith(fileSeparator)) {
-                fName += fileSeparator;
+                fName += "/";
             }
             zOut.putNextEntry(new ZipEntry(fName));
             zOut.closeEntry();


### PR DESCRIPTION
A bug caused nested jars packed on windows with JRD to be not openable by JRD. This was caused by replacing hardcoded "/" with fileseparator. This is relevant to https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4629919