### PR TITLE
Fixed return of untransformed bytecode of overwritten classes

### DIFF
--- a/decompiler_agent/src/main/java/org/jrd/agent/InstrumentationProvider.java
+++ b/decompiler_agent/src/main/java/org/jrd/agent/InstrumentationProvider.java
@@ -35,15 +35,15 @@ public class InstrumentationProvider {
 
     private byte[] getClassBody(Class clazz) throws UnmodifiableClassException {
         byte[] result;
-
         transformer.allowToSaveBytecode();
-        instrumentation.retransformClasses(clazz);
-        String nameWithSlashes = clazz.getName().replace(".", "/");
-        result = transformer.getResult(nameWithSlashes);
-
-        transformer.denyToSaveBytecode(); //should be in finally?
-        transformer.resetLastValidResult();
-
+        try {
+            String nameWithSlashes = clazz.getName().replace(".", "/");
+            instrumentation.retransformClasses(clazz);
+            result = transformer.getResult(nameWithSlashes);
+        } finally {
+            transformer.denyToSaveBytecode();
+            transformer.resetLastValidResult();
+        }
         return result;
     }
 

--- a/decompiler_agent/src/main/java/org/jrd/agent/Transformer.java
+++ b/decompiler_agent/src/main/java/org/jrd/agent/Transformer.java
@@ -22,10 +22,12 @@ public class Transformer implements ClassFileTransformer {
             ClassLoader loader, String className, Class<?> clazz, ProtectionDomain domain, byte[] classfileBuffer
     ) throws IllegalClassFormatException {
         if (allowToSaveBytecode) {
-            results.put(className, classfileBuffer);
             byte[] b = overrides.get(className);
             if (b != null) {
+                results.put(className, b);
                 return b;
+            } else {
+                results.put(className, classfileBuffer);
             }
         }
         return null;


### PR DESCRIPTION
As it was, our own return, contained original, untrasnformed byte[]
Now it returns bytecode correctly in by-us trasnformed form