### PR TITLE
Add jdk 17 to Java CI checks

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -16,16 +16,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        java-version: [ 11, 17 ]
       fail-fast: false
 
+    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
     steps:
       - name: Checkout JRD repo
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
           cache: maven
 


### PR DESCRIPTION
During Devconf I have tried to build JRC with JDK17 but failed. I made a small change to PR check so you can see what is happening there. You need to approve running workflow though. Or see the results here: https://github.com/dupliaka/java-runtime-decompiler/runs/4991200164?check_suite_focus=true